### PR TITLE
Make FixedLengthKey levels constant

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fixie-trie"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Julian Squires <julian@cipht.net>"]
 publish = false
 


### PR DESCRIPTION
The last time I looked at this, rust-lang/rust#29646 wasn't finished,
but now it is.  This avoids the possibility of a pathological
implementer of FixedLengthKey returning varying values for levels.

(Thanks Raph!)